### PR TITLE
Add strip_prefix option

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ s3_force_path_style = true
 disable_ssl = false
 bucket = "BUCKET"
 key_prefix = "PREFIX"
+strip_prefix = "PREFIX"
 bucket_url = "s3://BUCKET/PREFIX"
 profile = "profile"
 region = "ap-northeast-1"
@@ -130,9 +131,22 @@ aws_secret_access_key = "bbb"
 
 * `key_prefix` (required when `bucket_url` is unspecified)
 
-	Specifies the prefix prepended to the file path sent from the client.  The key string is derived as follows:
+	Specifies the prefix prepended to the file path sent from the client. The key string is derived as follows:
 
 		`key` = `key_prefix` + `path`
+
+  `strip_prefix` (optional)
+
+    Specifies the prefix stripped from the requests sent from the client, i.e.:
+
+        `bucket` = `my_bucket`
+        `key_prefix` = `my_prefix`
+        `strip_prefix` = `something_I_dont_want`
+
+        The following request paths would be equivalent:
+
+        `s3://my_bucket/my_prefix/something_I_dont_want/something_I_want.txt`
+        `s3://my_bucket/my_prefix/something_I_want.txt`
 
 * `bucket_url` (required when `bucket` is unspecified)
 

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ aws_secret_access_key = "bbb"
 
 		`key` = `key_prefix` + `path`
 
-  `strip_prefix` (optional)
+* `strip_prefix` (optional)
 
     Specifies the prefix stripped from the requests sent from the client, i.e.:
 
@@ -143,7 +143,7 @@ aws_secret_access_key = "bbb"
         `key_prefix` = `my_prefix`
         `strip_prefix` = `something_I_dont_want`
 
-        The following request paths would be equivalent:
+    The following request paths would be equivalent:
 
         `s3://my_bucket/my_prefix/something_I_dont_want/something_I_want.txt`
         `s3://my_bucket/my_prefix/something_I_want.txt`

--- a/bucket.go
+++ b/bucket.go
@@ -65,7 +65,7 @@ type S3Bucket struct {
 	AWSConfig                      *aws.Config
 	Bucket                         string
 	KeyPrefix                      Path
-	StripPrefix                    string
+	StripPrefix                    Path
 	MaxObjectSize                  int64
 	Users                          UserStore
 	Perms                          Perms
@@ -139,6 +139,10 @@ func buildS3Bucket(uStores UserStores, name string, bCfg *S3BucketConfig) (*S3Bu
 	if len(keyPrefix) > 0 && keyPrefix[0] == "" {
 		keyPrefix = keyPrefix[1:]
 	}
+	stripPrefix := SplitIntoPath(bCfg.StripPrefix)
+	if len(stripPrefix) > 0 && stripPrefix[0] == "" {
+		stripPrefix = stripPrefix[1:]
+	}
 	maxObjectSize := int64(-1)
 	if bCfg.MaxObjectSize != nil {
 		maxObjectSize = *bCfg.MaxObjectSize
@@ -163,7 +167,7 @@ func buildS3Bucket(uStores UserStores, name string, bCfg *S3BucketConfig) (*S3Bu
 		AWSConfig:     awsCfg,
 		Bucket:        bCfg.Bucket,
 		KeyPrefix:     keyPrefix,
-		StripPrefix:   bCfg.StripPrefix,
+		StripPrefix:   stripPrefix,
 		MaxObjectSize: maxObjectSize,
 		Users:         users,
 		Perms: Perms{

--- a/bucket.go
+++ b/bucket.go
@@ -70,6 +70,7 @@ type S3Bucket struct {
 	Perms                          Perms
 	ServerSideEncryption           ServerSideEncryptionConfig
 	KeyboardInteractiveAuthEnabled bool
+	StripPrefix                    string
 }
 
 type S3Buckets struct {
@@ -162,6 +163,7 @@ func buildS3Bucket(uStores UserStores, name string, bCfg *S3BucketConfig) (*S3Bu
 		AWSConfig:     awsCfg,
 		Bucket:        bCfg.Bucket,
 		KeyPrefix:     keyPrefix,
+		StripPrefix:   bCfg.StripPrefix,
 		MaxObjectSize: maxObjectSize,
 		Users:         users,
 		Perms: Perms{

--- a/bucket.go
+++ b/bucket.go
@@ -65,12 +65,12 @@ type S3Bucket struct {
 	AWSConfig                      *aws.Config
 	Bucket                         string
 	KeyPrefix                      Path
+	StripPrefix                    string
 	MaxObjectSize                  int64
 	Users                          UserStore
 	Perms                          Perms
 	ServerSideEncryption           ServerSideEncryptionConfig
 	KeyboardInteractiveAuthEnabled bool
-	StripPrefix                    string
 }
 
 type S3Buckets struct {

--- a/bucketio.go
+++ b/bucketio.go
@@ -559,7 +559,11 @@ type S3BucketIO struct {
 }
 
 func buildKey(s3b *S3Bucket, path string) Path {
-	return s3b.KeyPrefix.Join(SplitIntoPath(path))
+	p := SplitIntoPath(path)
+	if len(p) > 1 && p[1] == s3b.StripPrefix {
+		p = p[2:]
+	}
+	return s3b.KeyPrefix.Join(p)
 }
 
 func (s3io *S3BucketIO) Fileread(req *sftp.Request) (io.ReaderAt, error) {

--- a/bucketio.go
+++ b/bucketio.go
@@ -560,7 +560,7 @@ type S3BucketIO struct {
 
 func buildKey(s3b *S3Bucket, path string) Path {
 	p := SplitIntoPath(path)
-	if len(p) > 1 && p[1] == s3b.StripPrefix {
+	if len(p) > 1 && p[1] == Path.String(s3b.StripPrefix) {
 		p = p[2:]
 	}
 	return s3b.KeyPrefix.Join(p)

--- a/config.go
+++ b/config.go
@@ -38,6 +38,7 @@ type S3BucketConfig struct {
 	S3ForcePathStyle               *bool                    `toml:"s3_force_path_style"`
 	Bucket                         string                   `toml:"bucket"`
 	KeyPrefix                      string                   `toml:"key_prefix"`
+	StripPrefix                    string                   `toml:"strip_prefix"`
 	BucketUrl                      *URL                     `toml:"bucket_url"`
 	Auth                           string                   `toml:"auth"`
 	MaxObjectSize                  *int64                   `toml:"max_object_size"`
@@ -48,7 +49,6 @@ type S3BucketConfig struct {
 	SSECustomerKey                 string                   `toml:"sse_customer_key"`
 	SSEKMSKeyId                    string                   `toml:"sse_kms_key_id"`
 	KeyboardInteractiveAuthEnabled bool                     `toml:"keyboard_interactive_auth"`
-	StripPrefix                    string                   `toml:"strip_prefix"`
 }
 
 type AuthUser struct {

--- a/config.go
+++ b/config.go
@@ -48,6 +48,7 @@ type S3BucketConfig struct {
 	SSECustomerKey                 string                   `toml:"sse_customer_key"`
 	SSEKMSKeyId                    string                   `toml:"sse_kms_key_id"`
 	KeyboardInteractiveAuthEnabled bool                     `toml:"keyboard_interactive_auth"`
+	StripPrefix                    string                   `toml:"strip_prefix"`
 }
 
 type AuthUser struct {


### PR DESCRIPTION
This is a dirty way to allow stripping some prefix from the request client sends.

For example with:
`strip_prefix=data`

```
ls /data/
```
would be equivalent to
```
ls /
```