### PR TITLE
Address multiple linter warnings

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -21,6 +21,12 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y musl-tools
 
+    - name: Install golintci
+      run: |
+        set -x
+        export GOPATH=$GITHUB_WORKSPACE/go
+        curl https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "$(go env GOPATH)/bin" v1.22.2
+
     - name: Prepare workspace
       run: |
         set -x
@@ -39,6 +45,13 @@ jobs:
             curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
             $GOPATH/bin/dep ensure
         fi
+
+    - name: Run linter
+      run: |
+        set -x
+        export GOPATH=$GITHUB_WORKSPACE/go
+        cd $GOPATH/src/s3-sftp-proxy/
+        golangci-lint run
 
     - name: Build libc version
       run: |

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -50,6 +50,7 @@ jobs:
       run: |
         set -x
         export GOPATH=$GITHUB_WORKSPACE/go
+        export PATH=$PATH:$GOPATH/bin
         cd $GOPATH/src/s3-sftp-proxy/
         golangci-lint run
 

--- a/bucket.go
+++ b/bucket.go
@@ -81,8 +81,7 @@ type S3Buckets struct {
 }
 
 func (s3bs *S3Buckets) Get(name string) *S3Bucket {
-	b, _ := s3bs.Buckets[name]
-	return b
+	return s3bs.Buckets[name]
 }
 
 func (s3b *S3Bucket) S3(sess *aws_session.Session) *s3.S3 {

--- a/bucket.go
+++ b/bucket.go
@@ -117,9 +117,8 @@ func buildS3Bucket(uStores UserStores, name string, bCfg *S3BucketConfig) (*S3Bu
 				bCfg.Profile,
 			),
 		)
-	} else {
-		// credentials are retrieved through EC2 metadata on runtime
 	}
+	// credentials are retrieved through EC2 metadata on runtime otherwise
 	if bCfg.Endpoint != "" {
 		awsCfg = awsCfg.WithEndpoint(bCfg.Endpoint)
 	}

--- a/bucket.go
+++ b/bucket.go
@@ -159,7 +159,10 @@ func buildS3Bucket(uStores UserStores, name string, bCfg *S3BucketConfig) (*S3Bu
 			return nil, errors.Wrapf(err, `invalid base64-encoded string specified for "sse_customer_key"`)
 		}
 		hasher := crypto.MD5.New()
-		hasher.Write(customerKey)
+		_, err = hasher.Write(customerKey)
+		if err != nil {
+			return nil, errors.Wrapf(err, `customerKey hashing failed`)
+		}
 		customerKeyMD5 = base64.StdEncoding.EncodeToString(hasher.Sum([]byte{}))
 	} else {
 		customerKey = []byte{}

--- a/bucketio.go
+++ b/bucketio.go
@@ -24,10 +24,6 @@ type ReadDeadlineSettable interface {
 	SetReadDeadline(t time.Time) error
 }
 
-type WriteDeadlineSettable interface {
-	SetWriteDeadline(t time.Time) error
-}
-
 var sseTypes = map[ServerSideEncryptionType]*string{
 	ServerSideEncryptionTypeKMS: aws.String("aws:kms"),
 }

--- a/bucketio.go
+++ b/bucketio.go
@@ -127,7 +127,10 @@ func (oor *S3GetObjectOutputReader) ReadAt(buf []byte, off int64) (int, error) {
 	}()
 	select {
 	case <-oor.Ctx.Done():
-		oor.Goo.Body.(ReadDeadlineSettable).SetReadDeadline(time.Unix(1, 0))
+		err = oor.Goo.Body.(ReadDeadlineSettable).SetReadDeadline(time.Unix(1, 0))
+		if err != nil {
+			oor.Log.Debug("ReadAt SetReadDeadline failed")
+		}
 		oor.Log.Debug("canceled")
 		return 0, fmt.Errorf("read operation canceled")
 	case res := <-resultChan:

--- a/main.go
+++ b/main.go
@@ -180,7 +180,7 @@ func main() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	sigChan := make(chan os.Signal)
+	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan, os.Interrupt)
 
 	errChan := make(chan error)

--- a/main.go
+++ b/main.go
@@ -60,7 +60,7 @@ func buildSSHServerConfig(buckets *S3Buckets, cfg *S3SFTPProxyConfig) (*ssh.Serv
 			if u.PublicKeys != nil {
 				keyMarshaled := key.Marshal()
 				for _, herKey := range u.PublicKeys {
-					if herKey.Type() == key.Type() && len(herKey.Marshal()) == len(keyMarshaled) && bytes.Compare(herKey.Marshal(), keyMarshaled) == 0 {
+					if herKey.Type() == key.Type() && len(herKey.Marshal()) == len(keyMarshaled) && bytes.Equal(herKey.Marshal(), keyMarshaled) {
 						return &ssh.Permissions{
 							Extensions: map[string]string{
 								"pubkey-fp": ssh.FingerprintSHA256(key),

--- a/main.go
+++ b/main.go
@@ -13,8 +13,8 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/sirupsen/logrus"
 	"golang.org/x/crypto/ssh"
 )
 
@@ -172,10 +172,10 @@ func main() {
 	http.Handle(metricsEndpoint, promhttp.Handler())
 
 	go func() {
-	    http.ListenAndServe(metricsBind, nil)
+		logger.Fatal(http.ListenAndServe(metricsBind, nil))
 	}()
 
-    logger.Info("Metrics listen on ", metricsBind, metricsEndpoint)
+	logger.Info("Metrics listen on ", metricsBind, metricsEndpoint)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/phantom_object_map.go
+++ b/phantom_object_map.go
@@ -10,7 +10,7 @@ type PhantomObjectInfo struct {
 	LastModified time.Time
 	Size         int64
 	Opaque       interface{}
-	Mtx          sync.Mutex
+	Mtx          *sync.Mutex
 }
 
 func (info *PhantomObjectInfo) GetOne() PhantomObjectInfo {

--- a/server.go
+++ b/server.go
@@ -78,7 +78,10 @@ func (s *Server) HandleChannel(ctx context.Context, bucket *S3Bucket, sshCh ssh.
 				if req.Type == "subsystem" && string(req.Payload[4:]) == "sftp" {
 					ok = true
 				}
-				req.Reply(ok, nil)
+				err := req.Reply(ok, nil)
+				if err != nil {
+					s.Log.Debug("Channel reply failed")
+				}
 			}
 		}
 	}()

--- a/server.go
+++ b/server.go
@@ -140,7 +140,7 @@ func (s *Server) HandleClient(ctx context.Context, conn *net.TCPConn) error {
 	go func(reqs <-chan *ssh.Request) {
 		defer wg.Done()
 		defer s.Log.Debug("HandleClient.requestHandler ended")
-		for _ = range reqs {
+		for range reqs {
 		}
 	}(reqs)
 

--- a/server.go
+++ b/server.go
@@ -151,7 +151,10 @@ func (s *Server) HandleClient(ctx context.Context, conn *net.TCPConn) error {
 		defer s.Log.Debug("HandleClient.channelHandler ended")
 		for newSSHCh := range chans {
 			if newSSHCh.ChannelType() != "session" {
-				newSSHCh.Reject(ssh.UnknownChannelType, "unknown channel type")
+				err := newSSHCh.Reject(ssh.UnknownChannelType, "unknown channel type")
+				if err != nil {
+					F(s.Log.Debug, "channel reject failed: %s", err)
+				}
 				F(s.Log.Info, "unknown channel type: %s", newSSHCh.ChannelType())
 				continue
 			}

--- a/server.go
+++ b/server.go
@@ -33,7 +33,7 @@ func asHandlers(handlers interface {
 	sftp.FileCmder
 	sftp.FileLister
 }) sftp.Handlers {
-	return sftp.Handlers{handlers, handlers, handlers, handlers}
+	return sftp.Handlers{FileGet: handlers, FilePut: handlers, FileCmd: handlers, FileList: handlers}
 }
 
 func (s *Server) HandleChannel(ctx context.Context, bucket *S3Bucket, sshCh ssh.Channel, reqs <-chan *ssh.Request) {

--- a/server.go
+++ b/server.go
@@ -118,7 +118,7 @@ func (s *Server) HandleClient(ctx context.Context, conn *net.TCPConn) error {
 		<-innerCtx.Done()
 		err := conn.SetDeadline(time.Unix(1, 0))
 		if err != nil {
-			s.Log.Debug("SetDeadline failed")
+			s.Log.Debug("HandleClient SetDeadline failed")
 		}
 	}()
 
@@ -216,7 +216,10 @@ outer:
 				}
 			}()
 		case <-ctx.Done():
-			lsnr.SetDeadline(time.Unix(1, 0))
+			err := lsnr.SetDeadline(time.Unix(1, 0))
+			if err != nil {
+				s.Log.Debug("RunListenerEventLoop SetDeadline failed")
+			}
 			break outer
 		}
 	}

--- a/server.go
+++ b/server.go
@@ -116,7 +116,10 @@ func (s *Server) HandleClient(ctx context.Context, conn *net.TCPConn) error {
 
 	go func() {
 		<-innerCtx.Done()
-		conn.SetDeadline(time.Unix(1, 0))
+		err := conn.SetDeadline(time.Unix(1, 0))
+		if err != nil {
+			s.Log.Debug("SetDeadline failed")
+		}
 	}()
 
 	// Before use, a handshake must be performed on the incoming net.Conn.

--- a/server.go
+++ b/server.go
@@ -222,7 +222,7 @@ outer:
 	}
 
 	// drain
-	for _ = range connChan {
+	for range connChan {
 	}
 
 	wg.Wait()

--- a/user.go
+++ b/user.go
@@ -27,8 +27,7 @@ func (us *UserStore) Add(u *User) {
 }
 
 func (us *UserStore) Lookup(name string) *User {
-	u, _ := us.usersMap[name]
-	return u
+	return us.usersMap[name]
 }
 
 func parseAuthorizedKeys(pubKeys []ssh.PublicKey, pubKeyFileContent []byte) ([]ssh.PublicKey, error) {


### PR DESCRIPTION
```
# golangci-lint run
bucket.go:162:15: Error return value of `hasher.Write` is not checked (errcheck)
		hasher.Write(customerKey)
		            ^
bucketio.go:134:54: Error return value of `(s3-sftp-proxy.ReadDeadlineSettable).SetReadDeadline` is not checked (errcheck)
		oor.Goo.Body.(ReadDeadlineSettable).SetReadDeadline(time.Unix(1, 0))
		                                                   ^
main.go:175:25: Error return value of `http.ListenAndServe` is not checked (errcheck)
	    http.ListenAndServe(metricsBind, nil)
	                       ^
server.go:81:14: Error return value of `req.Reply` is not checked (errcheck)
				req.Reply(ok, nil)
				         ^
server.go:116:19: Error return value of `conn.SetDeadline` is not checked (errcheck)
		conn.SetDeadline(time.Unix(1, 0))
		                ^
server.go:148:20: Error return value of `newSSHCh.Reject` is not checked (errcheck)
				newSSHCh.Reject(ssh.UnknownChannelType, "unknown channel type")
				               ^
server.go:213:20: Error return value of `lsnr.SetDeadline` is not checked (errcheck)
			lsnr.SetDeadline(time.Unix(1, 0))
			                ^
bucketio.go:27:6: `WriteDeadlineSettable` is unused (deadcode)
type WriteDeadlineSettable interface {
     ^
server.go:36:9: composites: `s3-sftp-proxy/vendor/github.com/pkg/sftp.Handlers` composite literal uses unkeyed fields (govet)
	return sftp.Handlers{handlers, handlers, handlers, handlers}
	       ^
phantom_object_map.go:19:9: copylocks: return copies lock value: s3-sftp-proxy.PhantomObjectInfo contains sync.Mutex (govet)
	return *info
	       ^
main.go:184:15: SA1017: the channel used with signal.Notify should be buffered (staticcheck)
	signal.Notify(sigChan, os.Interrupt)
	             ^
bucket.go:121:9: SA9003: empty branch (staticcheck)
	} else {
	       ^
main.go:63:86: S1004: should use bytes.Equal(herKey.Marshal(), keyMarshaled) instead (gosimple)
					if herKey.Type() == key.Type() && len(herKey.Marshal()) == len(keyMarshaled) && bytes.Compare(herKey.Marshal(), keyMarshaled) == 0 {
					                                                                                ^
bucket.go:84:2: S1005: should write `b := s3bs.Buckets[name]` instead of `b, _ := s3bs.Buckets[name]` (gosimple)
	b, _ := s3bs.Buckets[name]
	^
user.go:30:2: S1005: should write `u := us.usersMap[name]` instead of `u, _ := us.usersMap[name]` (gosimple)
	u, _ := us.usersMap[name]
	^
server.go:137:7: S1005: should omit values from range; this loop is equivalent to `for range ...` (gosimple)
		for _ = range reqs {
		    ^
server.go:219:6: S1005: should omit values from range; this loop is equivalent to `for range ...` (gosimple)
	for _ = range connChan {
	    ^
```